### PR TITLE
Add "Copy Author Name" Button in the `ehDownloadBox`

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -194,7 +194,7 @@ var ehDownloadStyle = '\
 		50% { -webkit-transform: translateX(0%) scaleX(0.7); transform: translateX(0%) scaleX(0.7); } \
 		to { -webkit-transform: translateX(50%) scaleX(0); transform: translateX(50%) scaleX(0); } \
 	} \
-	.ehD-box { margin: 20px auto; width: 732px; box-sizing: border-box; font-size: 12px; border: 1px groove #000000; }\
+    .ehD-box { margin: 20px auto; width: 870px; box-sizing: border-box; font-size: 12px; border: 1px groove #000000; }\
 	.ehD-box a { cursor: pointer; }\
 	.ehD-box .g2 { display: inline-block; margin: 10px; padding: 0; line-height: 14px; }\
 	.ehD-box legend { font-weight: 700; padding: 0 10px; } \
@@ -2399,6 +2399,23 @@ ehDownloadAction.addEventListener('click', function(event){
 	initEHDownload();
 });
 ehDownloadBox.appendChild(ehDownloadAction);
+
+var ehCopyAuthorName = document.createElement('div');
+ehCopyAuthorName.className = 'g2';
+ehCopyAuthorName.innerHTML = ehDownloadArrow + ' <a>Copy Author Name</a>';
+ehCopyAuthorName.addEventListener('click', function(event){
+    event.preventDefault();
+    var gj = document.getElementById('gj').innerHTML.match(/\[.*?\]/gm)[0].replace(/\[(.*)\]/, "$1");
+    var gn = document.getElementById('gn').innerHTML.match(/\[.*?\]/gm)[0];
+    const element = document.createElement('textarea');
+    element.value = gj + " " + gn;
+    ehDownloadBox.appendChild(element);
+    element.focus();
+    element.setSelectionRange(0, element.value.length);
+    document.execCommand('copy');
+    ehDownloadBox.removeChild(element);
+});
+ehDownloadBox.appendChild(ehCopyAuthorName);
 
 var ehDownloadNumberInput = document.createElement('div');
 ehDownloadNumberInput.className = 'g2';


### PR DESCRIPTION
![图片](https://user-images.githubusercontent.com/9620335/54483972-d6d13b80-4854-11e9-9b03-05b05e19af7f.png)
As shown in the screenshot, the button is added to the `ehDownloadBox` to copy the name of the author.

The intention is to organize the downloaded galleries according to the name of the author. This button simplifies the formatting process of the author name.

The format of the copied name is:
`<circle name> (<author name>) [<circle romaji name> (<author romaji name>)]`

Maybe it's better to add a setting to enable/disable this feature. Besides, maybe it's better to add a feature to allow users to download galleries directly into the directory with the name of the author?